### PR TITLE
Added support for `http.client.request.body.size` and `http.client.response.body.size`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ let client = ClientBuilder::new(reqwest::Client::new())
     .build();
 ```
 
+Supported metrics:
+* [`http.client.request.duration`](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpclientrequestduration)
+* [`http.client.request.body.size`](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpclientrequestbodysize)
+* [`http.client.response.body.size`](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpclientresponsebodysize)
+
 Supported labels:
 * `http_request_method`
 * `server_address`

--- a/tests/snapshots/integration_tests__basic.snap
+++ b/tests/snapshots/integration_tests__basic.snap
@@ -50,5 +50,97 @@ Snapshot(
             ),
             Histogram([HISTOGRAM_VALUE]),
         ),
+        (
+            CompositeKey(
+                Histogram,
+                Key {
+                    name: KeyName(
+                        "http.client.request.body.size",
+                    ),
+                    labels: [
+                        Label(
+                            "http.request.method",
+                            "GET",
+                        ),
+                        Label(
+                            "url.scheme",
+                            "http",
+                        ),
+                        Label(
+                            "network.protocol.name",
+                            "http",
+                        ),
+                        Label(
+                            "server.address",
+                            "127.0.0.1",
+                        ),
+                        Label("server.port", [PORT]),
+                        Label(
+                            "network.protocol.version",
+                            "1.1",
+                        ),
+                        Label(
+                            "http.response.status_code",
+                            "200",
+                        ),
+                    ],
+                    hashed: true,
+                    hash: [HASH],
+                },
+            ),
+            Some(
+                Bytes,
+            ),
+            Some(
+                "Size of HTTP client request bodies.",
+            ),
+            Histogram([HISTOGRAM_VALUE]),
+        ),
+        (
+            CompositeKey(
+                Histogram,
+                Key {
+                    name: KeyName(
+                        "http.client.response.body.size",
+                    ),
+                    labels: [
+                        Label(
+                            "http.request.method",
+                            "GET",
+                        ),
+                        Label(
+                            "url.scheme",
+                            "http",
+                        ),
+                        Label(
+                            "network.protocol.name",
+                            "http",
+                        ),
+                        Label(
+                            "server.address",
+                            "127.0.0.1",
+                        ),
+                        Label("server.port", [PORT]),
+                        Label(
+                            "network.protocol.version",
+                            "1.1",
+                        ),
+                        Label(
+                            "http.response.status_code",
+                            "200",
+                        ),
+                    ],
+                    hashed: true,
+                    hash: [HASH],
+                },
+            ),
+            Some(
+                Bytes,
+            ),
+            Some(
+                "Size of HTTP client response bodies.",
+            ),
+            Histogram([HISTOGRAM_VALUE]),
+        ),
     ],
 )

--- a/tests/snapshots/integration_tests__custom_labels.snap
+++ b/tests/snapshots/integration_tests__custom_labels.snap
@@ -50,5 +50,97 @@ Snapshot(
             ),
             Histogram([HISTOGRAM_VALUE]),
         ),
+        (
+            CompositeKey(
+                Histogram,
+                Key {
+                    name: KeyName(
+                        "http.client.request.body.size",
+                    ),
+                    labels: [
+                        Label(
+                            "method",
+                            "GET",
+                        ),
+                        Label(
+                            "scheme",
+                            "http",
+                        ),
+                        Label(
+                            "protocol.version",
+                            "http",
+                        ),
+                        Label(
+                            "host",
+                            "127.0.0.1",
+                        ),
+                        Label("port", [PORT]),
+                        Label(
+                            "network.protocol.version",
+                            "1.1",
+                        ),
+                        Label(
+                            "status",
+                            "200",
+                        ),
+                    ],
+                    hashed: true,
+                    hash: [HASH],
+                },
+            ),
+            Some(
+                Bytes,
+            ),
+            Some(
+                "Size of HTTP client request bodies.",
+            ),
+            Histogram([HISTOGRAM_VALUE]),
+        ),
+        (
+            CompositeKey(
+                Histogram,
+                Key {
+                    name: KeyName(
+                        "http.client.response.body.size",
+                    ),
+                    labels: [
+                        Label(
+                            "method",
+                            "GET",
+                        ),
+                        Label(
+                            "scheme",
+                            "http",
+                        ),
+                        Label(
+                            "protocol.version",
+                            "http",
+                        ),
+                        Label(
+                            "host",
+                            "127.0.0.1",
+                        ),
+                        Label("port", [PORT]),
+                        Label(
+                            "network.protocol.version",
+                            "1.1",
+                        ),
+                        Label(
+                            "status",
+                            "200",
+                        ),
+                    ],
+                    hashed: true,
+                    hash: [HASH],
+                },
+            ),
+            Some(
+                Bytes,
+            ),
+            Some(
+                "Size of HTTP client response bodies.",
+            ),
+            Histogram([HISTOGRAM_VALUE]),
+        ),
     ],
 )


### PR DESCRIPTION
This PR adds support for 2 more metrics from the Open Telemetry Semantic Conventions.

* [`http.client.request.body.size`](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpclientrequestbodysize)
* [`http.client.response.body.size`](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpclientresponsebodysize)

see: #2 
cc: @bonsairobo
